### PR TITLE
Switch to hyphenated slugs in generators

### DIFF
--- a/scripts/generate-entities.mjs
+++ b/scripts/generate-entities.mjs
@@ -14,14 +14,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { slugify } from './slugify.mjs';
+
 const SUPABASE_URL = process.env.SUPABASE_URL || 'https://adwobxutnpmjbmhdxrzx.supabase.co';
 const SUPABASE_ANON = process.env.SUPABASE_ANON || 'sb_publishable_uBZdKmgGql5sDNGpj1DVMQ_opZ2V4kV';
 
 const OUT_DIR = path.join(process.cwd(), 'src', 'generated');
-
-function slugifyName(name) {
-  return encodeURIComponent(String(name || '').replace(/\s+/g, ' ').trim());
-}
 
 async function fetchJSON(url) {
   const res = await fetch(url, {
@@ -50,7 +48,7 @@ async function genPlatforms() {
     out.push({
       id: p.id,
       name: p.name,
-      slug: slugifyName(p.name),
+      slug: slugify(p.name),
       meta: p.meta ?? null,
       createdAt: p.createdAt,
       updatedAt: p.updatedAt,
@@ -72,7 +70,7 @@ async function genBaseRoms() {
     out.push({
       id: b.id,
       name: b.name,
-      slug: slugifyName(b.name),
+      slug: slugify(b.name),
       gameId: b.gameId,
       gameRomId: b.gameRomId,
       createdAt: b.createdAt,
@@ -110,7 +108,7 @@ async function genGames() {
     out.push({
       id: g.id,
       name: g.name,
-      slug: slugifyName(g.name),
+      slug: slugify(g.name),
       meta: g.meta ?? null,
       platformId: g.platformId,
       developerId: g.developerId ?? null,
@@ -128,7 +126,7 @@ async function genDevelopers() {
   const out = rows.map((d) => ({
     id: d.id,
     name: d.name,
-    slug: slugifyName(d.name),
+    slug: slugify(d.name),
     meta: d.meta ?? null,
     platformId: d.platformId,
     createdAt: d.createdAt,
@@ -143,7 +141,7 @@ async function genRegions() {
   const out = rows.map((r) => ({
     id: r.id,
     name: r.name,
-    slug: slugifyName(r.name),
+    slug: slugify(r.name),
     meta: r.meta ?? null,
     platformId: r.platformId,
     createdAt: r.createdAt,

--- a/scripts/generate-gameroms.mjs
+++ b/scripts/generate-gameroms.mjs
@@ -10,13 +10,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { slugify } from './slugify.mjs';
+
 const SUPABASE_URL = process.env.SUPABASE_URL || 'https://adwobxutnpmjbmhdxrzx.supabase.co';
 const SUPABASE_ANON = process.env.SUPABASE_ANON || 'sb_publishable_uBZdKmgGql5sDNGpj1DVMQ_opZ2V4kV';
 const OUT_FILE = path.join(process.cwd(), 'src', 'generated', 'gameroms.json');
-
-function slugify(name) {
-  return encodeURIComponent(String(name || '').replace(/\s+/g, ' ').trim());
-}
 
 async function fetchJSON(url) {
   const res = await fetch(url, {

--- a/scripts/generate-projects.mjs
+++ b/scripts/generate-projects.mjs
@@ -9,15 +9,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { slugify } from './slugify.mjs';
+
 const SUPABASE_URL = process.env.SUPABASE_URL || 'https://adwobxutnpmjbmhdxrzx.supabase.co';
 const SUPABASE_ANON = process.env.SUPABASE_ANON || 'sb_publishable_uBZdKmgGql5sDNGpj1DVMQ_opZ2V4kV';
 
 const OUTPUT_DIR = path.join(process.cwd(), 'src', 'generated');
 const OUTPUT_FILE = path.join(OUTPUT_DIR, 'projects.json');
-
-function slugifyName(name) {
-  return encodeURIComponent(name.replace(/\s+/g, ' ').trim());
-}
 
 async function fetchJSON(url) {
   const res = await fetch(url, {
@@ -39,7 +37,7 @@ async function listProjects() {
   return rows.map((p) => ({
     id: p.id,
     name: p.name,
-    slug: slugifyName(p.name),
+    slug: slugify(p.name),
     meta: p.meta ?? null,
     gameId: p.gameId,
     baseRomId: p.baseRomId,

--- a/scripts/slugify.mjs
+++ b/scripts/slugify.mjs
@@ -1,0 +1,13 @@
+export function slugify(value) {
+  const normalized = String(value ?? '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+  const hyphenated = normalized
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return hyphenated;
+}

--- a/src/generated/baseroms.json
+++ b/src/generated/baseroms.json
@@ -4,10 +4,10 @@
     "fetchedAt": "2025-09-16T23:00:27.424Z"
   },
   "baseRoms": {
-    "GaiaLabs%20BaseROM": {
+    "gaialabs-baserom": {
       "id": "cmfmf4tz4000eza34y2ahiivp",
       "name": "GaiaLabs BaseROM",
-      "slug": "GaiaLabs%20BaseROM",
+      "slug": "gaialabs-baserom",
       "gameId": "cmfmf4tgx0008za34pu5l6fna",
       "gameRomId": "cmfmf4tis000aza34iz8yg82o",
       "createdAt": "2025-09-16T10:37:00.736",

--- a/src/generated/developers.json
+++ b/src/generated/developers.json
@@ -4,10 +4,10 @@
     "fetchedAt": "2025-09-16T23:00:27.935Z"
   },
   "developers": {
-    "Enix": {
+    "enix": {
       "id": "cmfmf4tf10006za34fegrahlk",
       "name": "Enix",
-      "slug": "Enix",
+      "slug": "enix",
       "meta": {
         "romDeveloper": 51
       },

--- a/src/generated/gameroms.json
+++ b/src/generated/gameroms.json
@@ -8,19 +8,19 @@
       "platform": {
         "id": "cmfmf4t8c0000za347p07stzi",
         "name": "SNES",
-        "slug": "SNES"
+        "slug": "snes"
       },
       "game": {
         "id": "cmfmf4tgx0008za34pu5l6fna",
         "name": "Illusion of Gaia",
-        "slug": "Illusion%20of%20Gaia"
+        "slug": "illusion-of-gaia"
       },
       "region": {
         "id": "cmfmf4td70004za34671tza75",
         "name": "US",
-        "slug": "US"
+        "slug": "us"
       },
-      "path": "games/SNES/Illusion%20of%20Gaia/US",
+      "path": "games/snes/illusion-of-gaia/us",
       "branch": {
         "id": "cmfmf4tn9000cza34rhpxv1fp",
         "name": "1.0",

--- a/src/generated/games.json
+++ b/src/generated/games.json
@@ -4,10 +4,10 @@
     "fetchedAt": "2025-09-16T23:00:27.822Z"
   },
   "games": {
-    "Illusion%20of%20Gaia": {
+    "illusion-of-gaia": {
       "id": "cmfmf4tgx0008za34pu5l6fna",
       "name": "Illusion of Gaia",
-      "slug": "Illusion%20of%20Gaia",
+      "slug": "illusion-of-gaia",
       "meta": {
         "ramSize": 3,
         "romMode": 49,

--- a/src/generated/platforms.json
+++ b/src/generated/platforms.json
@@ -4,10 +4,10 @@
     "fetchedAt": "2025-09-16T23:00:27.254Z"
   },
   "platforms": {
-    "SNES": {
+    "snes": {
       "id": "cmfmf4t8c0000za347p07stzi",
       "name": "SNES",
-      "slug": "SNES",
+      "slug": "snes",
       "meta": {},
       "createdAt": "2025-09-16T10:36:59.773",
       "updatedAt": "2025-09-16T10:36:59.773",

--- a/src/generated/projects.json
+++ b/src/generated/projects.json
@@ -7,7 +7,7 @@
     {
       "id": "cmfmf4vbv002yza34yjzv0w0l",
       "name": "Illusion of Gaia: Retranslated",
-      "slug": "Illusion%20of%20Gaia%3A%20Retranslated",
+      "slug": "illusion-of-gaia-retranslated",
       "meta": {
         "currentVersion": "1.41"
       },

--- a/src/generated/regions.json
+++ b/src/generated/regions.json
@@ -4,10 +4,10 @@
     "fetchedAt": "2025-09-16T23:00:28.014Z"
   },
   "regions": {
-    "US": {
+    "us": {
       "id": "cmfmf4td70004za34671tza75",
       "name": "US",
-      "slug": "US",
+      "slug": "us",
       "meta": {
         "romRegion": 1
       },


### PR DESCRIPTION
## Summary
- add a shared slugify helper that normalizes names into lowercase hyphenated identifiers
- update the entity, GameRom, and Project generators to use the shared helper for every slug and generated path
- refresh the generated JSON snapshots so prebuilt data now uses the new slug format

## Testing
- pnpm generate:entities *(fails: fetch failed – Supabase host unreachable from CI environment)*
- pnpm generate:gameroms *(fails: fetch failed – Supabase host unreachable from CI environment)*
- pnpm generate:projects *(fails: fetch failed – Supabase host unreachable from CI environment)*
- pnpm build *(fails: fetch failed – Prisma schema URL unreachable from CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca23b53f788332bb6e8b7849a445a6